### PR TITLE
Fix components

### DIFF
--- a/src/components/hooks/loop_var.rs
+++ b/src/components/hooks/loop_var.rs
@@ -1,0 +1,9 @@
+use super::super::r#loop::{LoopDataContext, LoopVar};
+use yew::{hook, use_context};
+
+#[hook]
+fn use_loop_var<T: Clone + Default + PartialEq + 'static>() -> LoopVar<T> {
+    let ctx: Option<LoopDataContext<T>> = use_context::<LoopDataContext<T>>();
+
+    ctx.as_ref().map(|v| v.get_var()).unwrap_or_default()
+}

--- a/src/components/hooks/mod.rs
+++ b/src/components/hooks/mod.rs
@@ -1,0 +1,5 @@
+mod loop_var;
+mod reactor;
+mod signal;
+
+pub use self::{signal::use_signal, reactor::use_reactor};

--- a/src/components/hooks/reactor.rs
+++ b/src/components/hooks/reactor.rs
@@ -1,0 +1,12 @@
+use super::super::reactor::ReactorDataContext;
+use crate::signal::Runtime;
+use yew::{hook, use_context};
+use std::sync::Arc;
+
+#[hook]
+pub fn use_reactor() -> Arc<Runtime> {
+    match use_context::<ReactorDataContext>().map(|ctx| ctx.runtime()) {
+        Some(rt) => rt,
+        None => Runtime::new(),
+    }
+}

--- a/src/components/hooks/signal.rs
+++ b/src/components/hooks/signal.rs
@@ -1,0 +1,8 @@
+use super::use_reactor;
+use crate::signal::Signal;
+use yew::hook;
+
+#[hook]
+pub fn use_signal<T: 'static>(v: T) -> Signal<T> {
+    use_reactor().create_signal(v)
+}

--- a/src/components/loop/component.rs
+++ b/src/components/loop/component.rs
@@ -9,8 +9,8 @@ pub enum Msg {
 
 #[derive(Properties)]
 pub struct Props<C: KeyedCollection> {
-    pub values:   Signal<C>,
-    pub children: Children,
+    pub(crate) values:   Signal<C>,
+    pub(crate) children: Children,
 }
 
 impl<C: KeyedCollection> PartialEq for Props<C> {
@@ -27,7 +27,7 @@ pub struct For<T: Clone + PartialEq + Default + 'static, C: KeyedCollection> {
     c:      PhantomData<C>,
 }
 
-impl<T: Clone + PartialEq + Default + 'static, C: KeyedCollection<Value = T>> For<T, C> {
+impl<T: Default + Clone + PartialEq + 'static, C: KeyedCollection<Value = T>> For<T, C> {
     fn make_item(children: &Children, values: Signal<C>, key: &str) -> Html {
         let value = values.runtime().create_keyed_signal(values, key);
         let key = key.to_string();
@@ -50,7 +50,7 @@ impl<T: Clone + PartialEq + Default + 'static, C: KeyedCollection<Value = T>> Fo
     }
 }
 
-impl<T: Clone + PartialEq + Default + 'static, C: KeyedCollection<Value = T>> Component for For<T, C> {
+impl<T: Default + Clone + PartialEq + 'static, C: KeyedCollection<Value = T>> Component for For<T, C> {
     type Message = Msg;
     type Properties = Props<C>;
 

--- a/src/components/loop/context.rs
+++ b/src/components/loop/context.rs
@@ -1,0 +1,90 @@
+use super::element::LoopElement;
+use crate::signal::Signal;
+use yew::{
+    html::{Scope, AnyScope},
+    Component,
+    Context,
+};
+
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
+pub struct LoopVar<T: Clone + Default + 'static> {
+    value: Option<Signal<Option<T>>>,
+}
+
+impl<T: Clone + Default + 'static> LoopVar<T> {
+    pub(in super::super) fn new(value: Option<Signal<Option<T>>>) -> Self {
+        Self {
+            value,
+        }
+    }
+
+    pub fn with_value<R, F>(&self, f: F) -> R
+    where
+        for<'a> F: FnOnce(Option<&'a T>) -> R, {
+        match self.value.as_ref() {
+            Some(value) => value.with(|v| f(v.as_ref())),
+            None => f(None),
+        }
+    }
+
+    pub fn get_value(&self) -> Option<T> {
+        self.value.as_ref().and_then(|v| v.with(|v| v.clone()))
+    }
+}
+
+#[derive(Clone)]
+pub(in super::super) struct LoopDataContext<T: 'static> {
+    signal: Signal<Option<T>>,
+}
+
+impl<T: Clone + Default + PartialEq + 'static> LoopDataContext<T> {
+    pub(super) fn new(signal: Signal<Option<T>>) -> Self {
+        Self {
+            signal,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(in super::super) fn get_var(&self) -> LoopVar<T> {
+        LoopVar::new(Some(self.signal.clone()))
+    }
+}
+
+impl<T: 'static> Eq for LoopDataContext<T> {}
+
+impl<T: 'static> PartialEq for LoopDataContext<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.signal == other.signal
+    }
+}
+
+/// Component extension trait for Loop component
+pub trait LoopContext {
+    fn get_loop_var<T: Clone + Default + PartialEq + 'static>(&self) -> LoopVar<T>;
+}
+
+impl<C: Component> LoopContext for Context<C> {
+    fn get_loop_var<T: Clone + Default + PartialEq + 'static>(&self) -> LoopVar<T> {
+        self.link().get_loop_var()
+    }
+}
+
+impl<C: Component> LoopContext for Scope<C> {
+    fn get_loop_var<T: Clone + Default + PartialEq + 'static>(&self) -> LoopVar<T> {
+        LoopVar::new(get_loop_var_from_scope(self))
+    }
+}
+
+fn get_loop_var_from_scope<C, T>(scope: &Scope<C>) -> Option<Signal<Option<T>>>
+where
+    C: Component,
+    T: Clone + Default + PartialEq + 'static, {
+    get_loop_var(scope.get_parent()?)
+}
+
+fn get_loop_var<T: Clone + Default + PartialEq + 'static>(scope: &AnyScope) -> Option<Signal<Option<T>>> {
+    match scope.try_downcast::<LoopElement<T>>() {
+        None => get_loop_var(scope.get_parent()?),
+        Some(scope) => Some(scope.get_component()?.get_signal()),
+    }
+}

--- a/src/components/loop/element.rs
+++ b/src/components/loop/element.rs
@@ -1,12 +1,6 @@
+use super::LoopDataContext;
 use crate::signal::Signal;
-use yew::{Children, Component, Context, Html, html, Properties};
-use std::marker::PhantomData;
-use std::sync::Arc;
-
-pub enum ElementMsg {
-    SetBody(Html),
-    SetCondition(bool),
-}
+use yew::{context::ContextProvider, Children, Component, Context, Html, Properties, ToHtml, html};
 
 #[derive(Properties)]
 pub(crate) struct Props<T: Clone + Default + 'static> {
@@ -23,124 +17,45 @@ impl<T: Clone + Default + 'static> PartialEq for Props<T> {
 impl<T: Clone + Default + 'static> Eq for Props<T> {}
 
 pub(crate) struct LoopElement<T: Clone + Default + 'static> {
-    condition: bool,
-    signal:    Signal<T>,
-    children:  Html,
-    ty:        PhantomData<T>,
+    value: Signal<Option<T>>,
 }
 
 impl<T: Clone + Default + 'static> LoopElement<T> {
-    fn make_body(value: &T, children: Children) -> Html {
-        html! {
-            {children}
-        }
+    pub(super) fn get_signal(&self) -> Signal<Option<T>> {
+        self.value.clone()
     }
 }
 
-impl<T: Clone + Default + 'static> Component for LoopElement<T> {
-    type Message = ElementMsg;
+impl<T: Clone + Default + PartialEq + 'static> Component for LoopElement<T> {
+    type Message = ();
     type Properties = Props<T>;
 
     fn create(ctx: &Context<Self>) -> Self {
-        let props = ctx.props();
-        let condition = props.value.with(|v| v.is_some());
-        let (children, signal) = {
-            let rt = props.value.runtime();
-            let children = props.children.clone();
-
-            props.value.with(move |v| match v {
-                Some(v) => (Self::make_body(v, children), rt.create_signal(v.clone())),
-                None => (html!(), rt.create_signal(T::default())),
-            })
-        };
-
         Self {
-            condition,
-            signal,
-            children,
-            ty: PhantomData,
+            value: ctx.props().value.clone(),
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
-        match msg {
-            ElementMsg::SetCondition(condition) => {
-                let changed = self.condition != condition;
-                if changed {
-                    self.condition = condition;
-                }
+    fn changed(&mut self, ctx: &Context<Self>, old_props: &Self::Properties) -> bool {
+        let updated = if old_props.value != ctx.props().value {
+            self.value = ctx.props().value.clone();
 
-                changed
-            }
-
-            ElementMsg::SetBody(body) => {
-                let changed = self.children != body;
-                if changed {
-                    self.children = body;
-                }
-
-                changed
-            }
-        }
-    }
-
-    fn changed(&mut self, ctx: &Context<Self>, _old_props: &Self::Properties) -> bool {
-        let props = ctx.props();
-        let when = props.value.clone();
-        let children = props.children.clone();
-        let changed = {
-            let children = when.with(|v| match v {
-                Some(v) => Self::make_body(v, children.clone()),
-                None => html!(),
-            });
-
-            let changed = self.children != children;
-            if changed {
-                self.children = children;
-            }
-
-            changed
+            true
+        } else {
+            false
         };
 
-        {
-            let rt = when.runtime();
-            let scope = ctx.link().clone();
-            let value = Arc::clone(&rt).create_signal(T::default());
-
-            {
-                let scope = scope.clone();
-                let value = value.clone();
-
-                value.runtime().create_effect(move || {
-                    let children = children.clone();
-
-                    value.with(|v| {
-                        scope.send_message(ElementMsg::SetBody(Self::make_body(v, children)));
-                    });
-                });
-            }
-
-            rt.create_effect(move || {
-                let condition = when.with(|v| match v {
-                    None => false,
-                    Some(v) => {
-                        value.set(v.clone());
-                        true
-                    }
-                });
-
-                scope.send_message(ElementMsg::SetCondition(condition));
-            });
-        }
-
-        changed
+        updated || ctx.props().children != old_props.children
     }
 
-    fn view(&self, _ctx: &Context<Self>) -> Html {
-        if self.condition {
-            self.children.clone()
-        } else {
-            html!()
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let children = ctx.props().children.to_html();
+        let context = LoopDataContext::new(self.value.clone());
+
+        html! {
+            <ContextProvider<LoopDataContext<T>> {context}>
+                {children}
+            </ContextProvider<LoopDataContext<T>>>
         }
     }
 }

--- a/src/components/loop/mod.rs
+++ b/src/components/loop/mod.rs
@@ -1,4 +1,10 @@
 mod component;
+mod context;
 mod element;
 
-pub use self::component::For;
+pub(super) use context::LoopDataContext;
+
+pub use self::{
+    component::For,
+    context::{LoopContext, LoopVar},
+};

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,9 +1,13 @@
 mod condition;
 mod r#loop;
+mod reactor;
 mod values;
 
+pub mod hooks;
+
 pub use self::{
-    r#loop::For,
-    values::{Item, Value},
     condition::{IfTrue, IfFalse, AsBool},
+    reactor::{Reactor, ReactorContext},
+    r#loop::{For, LoopContext},
+    values::{Item, Value},
 };

--- a/src/components/reactor/component.rs
+++ b/src/components/reactor/component.rs
@@ -1,0 +1,103 @@
+use super::ReactorDataContext;
+use crate::{signal::Runtime, defer::DeferRunner, spawner::SpawnGenerator};
+use yew::{context::ContextProvider, Children, Component, Context, Html, Properties, ToHtml, html};
+use std::sync::Arc;
+
+#[derive(Properties, Default)]
+pub struct Props {
+    #[prop_or_default]
+    pub(crate) with_defer_runner: Option<Arc<dyn DeferRunner>>,
+
+    #[prop_or_default]
+    pub(crate) with_spawn_generator: Option<Arc<dyn SpawnGenerator>>,
+
+    pub(crate) children: Children,
+}
+
+impl Eq for Props {}
+
+impl PartialEq for Props {
+    fn eq(&self, other: &Self) -> bool {
+        if self.children != other.children {
+            return false;
+        }
+
+        let eq_runner = match (&self.with_defer_runner, &other.with_defer_runner) {
+            (Some(a), Some(b)) => Arc::ptr_eq(a, b),
+            (None, None) => true,
+            _ => false,
+        };
+
+        let eq_generator = match (&self.with_spawn_generator, &other.with_spawn_generator) {
+            (Some(a), Some(b)) => Arc::ptr_eq(a, b),
+            (None, None) => true,
+            _ => false,
+        };
+
+        eq_runner && eq_generator
+    }
+}
+
+pub struct Reactor {
+    rt: Arc<Runtime>,
+}
+
+impl Reactor {
+    pub fn runtime(&self) -> Arc<Runtime> {
+        Arc::clone(&self.rt)
+    }
+}
+
+impl Component for Reactor {
+    type Message = ();
+    type Properties = Props;
+
+    fn create(ctx: &Context<Self>) -> Self {
+        let mut rt = Runtime::new();
+
+        if let Some(runner) = ctx.props().with_defer_runner.as_ref() {
+            rt = rt.with_defer_runner(Arc::clone(runner));
+        }
+
+        if let Some(generator) = ctx.props().with_spawn_generator.as_ref() {
+            rt = rt.with_spawn_generator(Arc::clone(generator));
+        }
+
+        Self {
+            rt,
+        }
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>, old_props: &Self::Properties) -> bool {
+        match ctx.props().with_defer_runner {
+            Some(ref runner) => {
+                self.rt.defer_manager().set_runner(Arc::clone(runner));
+            }
+            None => {
+                self.rt.defer_manager().reset_runner();
+            }
+        }
+
+        match ctx.props().with_spawn_generator {
+            Some(ref generator) => {
+                self.rt.spawner().set_generator(Arc::clone(generator));
+            }
+            None => {
+                self.rt.spawner().reset_generator();
+            }
+        }
+
+        ctx.props().children != old_props.children
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let children = ctx.props().children.to_html();
+        let context = ReactorDataContext::new(Arc::clone(&self.rt));
+
+        html! {
+            <ContextProvider<ReactorDataContext> {context}>
+                {children}
+            </ContextProvider<ReactorDataContext>>
+        }
+    }
+}

--- a/src/components/reactor/context.rs
+++ b/src/components/reactor/context.rs
@@ -1,0 +1,49 @@
+use super::Reactor;
+use crate::signal::Runtime;
+use yew::{
+    html::{Scope, AnyScope},
+    Component,
+    Context,
+};
+use std::sync::Arc;
+
+#[derive(Clone, PartialEq, Eq)]
+pub(in super::super) struct ReactorDataContext {
+    rt: Arc<Runtime>,
+}
+
+impl ReactorDataContext {
+    pub(super) fn new(rt: Arc<Runtime>) -> Self {
+        Self {
+            rt,
+        }
+    }
+
+    pub(in super::super) fn runtime(&self) -> Arc<Runtime> {
+        Arc::clone(&self.rt)
+    }
+}
+
+/// Component extension trait for Reactor component
+pub trait ReactorContext {
+    fn runtime(&self) -> Option<Arc<Runtime>>;
+}
+
+impl<C: Component> ReactorContext for Context<C> {
+    fn runtime(&self) -> Option<Arc<Runtime>> {
+        self.link().runtime()
+    }
+}
+
+impl<C: Component> ReactorContext for Scope<C> {
+    fn runtime(&self) -> Option<Arc<Runtime>> {
+        get_runtime(self.get_parent()?)
+    }
+}
+
+fn get_runtime(scope: &AnyScope) -> Option<Arc<Runtime>> {
+    match scope.try_downcast::<Reactor>() {
+        None => get_runtime(scope.get_parent()?),
+        Some(scope) => Some(scope.get_component()?.runtime()),
+    }
+}

--- a/src/components/reactor/mod.rs
+++ b/src/components/reactor/mod.rs
@@ -1,0 +1,6 @@
+mod component;
+mod context;
+
+pub(super) use context::ReactorDataContext;
+
+pub use self::{component::Reactor, context::ReactorContext};

--- a/src/components/values/state.rs
+++ b/src/components/values/state.rs
@@ -33,7 +33,7 @@ impl<P: ValueProps + 'static, C: Component<Properties = P, Message = Message>> V
         let default_class_signal = Arc::clone(&rt).create_signal(String::new());
 
         if let Some(prop_classes) = props.classes().cloned() {
-            classes.link_to(&prop_classes);
+            prop_classes.link_to(&classes);
         }
 
         if let Some(prop_class_signal) = props.class_signal() {

--- a/src/components/values/value.rs
+++ b/src/components/values/value.rs
@@ -5,19 +5,19 @@ use std::marker::PhantomData;
 
 #[derive(Properties)]
 pub struct Props<T: ToString + 'static> {
-    pub signal: Signal<T>,
+    pub(crate) signal: Signal<T>,
 
     #[prop_or_default]
-    pub class: Option<AttrValue>,
+    pub(crate) class: Option<AttrValue>,
 
     #[prop_or_default]
-    pub class_signal: Option<Signal<String>>,
+    pub(crate) class_signal: Option<Signal<String>>,
 
     #[prop_or_default]
-    pub classes: Option<CssClasses>,
+    pub(crate) classes: Option<CssClasses>,
 
     #[prop_or_default]
-    pub element: Option<AttrValue>,
+    pub(crate) element: Option<AttrValue>,
 }
 
 impl<T: ToString + 'static> ValueProps for Props<T> {

--- a/src/css.rs
+++ b/src/css.rs
@@ -293,9 +293,13 @@ mod tests {
 
         assert_eq!(
             src.sorted_values(),
-            "class1 class2 class3",
-            "the CSS classes should be linked from the source"
+            "",
+            "the CSS classes should be linked from the source and the source values should take the destination values"
         );
+
+        src.add("class1");
+        src.add("class2");
+        src.add("class3");
 
         assert_eq!(
             dest.sorted_values(),

--- a/src/defer/runner.rs
+++ b/src/defer/runner.rs
@@ -1,5 +1,23 @@
-use std::sync::Arc;
+use std::{sync::Arc, rc::Rc};
 
 pub trait DeferRunner {
     fn run(&self, f: Arc<dyn Fn()>);
+}
+
+impl DeferRunner for Box<dyn DeferRunner> {
+    fn run(&self, f: Arc<dyn Fn()>) {
+        self.as_ref().run(f);
+    }
+}
+
+impl DeferRunner for Rc<dyn DeferRunner> {
+    fn run(&self, f: Arc<dyn Fn()>) {
+        self.as_ref().run(f);
+    }
+}
+
+impl DeferRunner for Arc<dyn DeferRunner> {
+    fn run(&self, f: Arc<dyn Fn()>) {
+        self.as_ref().run(f);
+    }
 }

--- a/src/spawner/future.rs
+++ b/src/spawner/future.rs
@@ -5,9 +5,7 @@ use std::{
     pin::Pin,
     future::Future,
     panic::UnwindSafe,
-    any::Any,
 };
-use std::fmt::Display;
 
 pub type FutureVoid = LocalFuture<()>;
 
@@ -59,6 +57,7 @@ mod tests {
     use super::*;
     use std::{
         panic::panic_any,
+        any::Any,
         sync::{
             atomic::{AtomicUsize, Ordering},
             Arc,

--- a/src/spawner/generator.rs
+++ b/src/spawner/generator.rs
@@ -1,5 +1,24 @@
 use super::FutureVoid;
+use std::{sync::Arc, rc::Rc};
 
 pub trait SpawnGenerator {
     fn spawn(&self, fut: FutureVoid);
+}
+
+impl SpawnGenerator for Box<dyn SpawnGenerator> {
+    fn spawn(&self, fut: FutureVoid) {
+        self.as_ref().spawn(fut);
+    }
+}
+
+impl SpawnGenerator for Rc<dyn SpawnGenerator> {
+    fn spawn(&self, fut: FutureVoid) {
+        self.as_ref().spawn(fut);
+    }
+}
+
+impl SpawnGenerator for Arc<dyn SpawnGenerator> {
+    fn spawn(&self, fut: FutureVoid) {
+        self.as_ref().spawn(fut);
+    }
 }


### PR DESCRIPTION
# Contents
- Create the component to put the runtime in a opaque context
- Add signal in component field, cause the signal will be removed when it will be in the effect
- Add hook:
  + for getting the runtime instance,
  + for getting the loop iteration variable,
  + for creating a signal
- Fixing generic constraints
- Create contexts for the runtime instance and loop variable
- Fixing the implementation of loop element
  + This simplier, just store the signal and use hook or a method on the component scope for getting the loop var
  + Children will get the iteration variable
  + The iteration variable won't be used for rendering the loop element
- Fixing some errors like in value state
- Fixing tests
- Add missing implementation for DeferRunner
  + To call runner when they are embed in a `Box<T>`,  a`Rc<T>`, or a `Arc<T>`.